### PR TITLE
fix: add make to extra_pkgs and correct package name for sovereign-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   ci:
     uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
     with:
-      repo: ${{ github.event.repository.name }}
+      repo: whisper-apr
+      extra_pkgs: make
     secrets: inherit
 


### PR DESCRIPTION
## Summary
- Adds `make` to `extra_pkgs` so vendored OpenSSL (`openssl-sys`) can compile from source inside the sovereign-ci container
- Hardcodes `repo: whisper-apr` instead of `${{ github.event.repository.name }}` (which resolves to `whisper.apr`) — dots are invalid in Cargo package names, so the fallback `-p "whisper.apr"` commands were failing

Closes #50

## Five-Whys
1. CI RED — openssl-sys build fails + clippy/test/coverage fallback commands fail
2. `openssl-sys` runs `make` during build — "Command 'make' not found"
3. `vendored` feature compiles OpenSSL from source (requires `make`)
4. Container has `libssl-dev` (system headers) but not `make` — vendored ignores system OpenSSL
5. `extra_pkgs` was not set; repo name mismatch (`whisper.apr` vs `whisper-apr`) was never caught because the primary cargo commands succeed when deps resolve

## Test plan
- [ ] CI passes (test, lint, coverage all green)
- [ ] Verify `make` is installed in container (`apt-get install -y make`)
- [ ] Verify `-p whisper-apr` resolves correctly in fallback commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)