### PR TITLE
perf(tests): fast validation fixtures + nightly-tier RTF benchmark tests

### DIFF
--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -1,4 +1,4 @@
-# Nightly Benchmarks — criterion performance tracking
+# Nightly Benchmarks — criterion performance tracking + perf-tier unit tests
 name: Nightly Bench
 on:
   schedule:
@@ -7,6 +7,8 @@ on:
 concurrency:
   group: bench-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   bench:
     uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
@@ -15,3 +17,47 @@ jobs:
       run_benchmarks: true
     secrets: inherit
 
+  # Perf-tier unit tests: the real-inference RTF breakdown tests in
+  # src/benchmark_generated.rs run an unoptimized Q4K decoder forward pass and
+  # are too slow for the PR gate, so they are marked `#[ignore]`. Their
+  # assertion logic (proportions/bottleneck/positivity) is also covered by the
+  # fast `test_synthetic_breakdown_*` tests on the PR gate, but we still run the
+  # real-inference versions here nightly so the end-to-end path keeps coverage.
+  perf-tests:
+    name: perf-tests (ignored)
+    runs-on: [self-hosted, clean-room]
+    container:
+      image: localhost:5000/sovereign-ci:stable
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Checkout sibling repos (path deps)
+        run: |
+          cd "$GITHUB_WORKSPACE/.."
+          for repo in provable-contracts probar trueno trueno-rag trueno-db trueno-viz alimentar presentar aprender renacer batuta realizar; do
+            if [ -e "$repo" ] && [ ! -d "$repo" ]; then rm -f "$repo"; fi
+            if [ -d "$repo" ]; then
+              git -C "$repo" fetch --depth 1 origin main 2>/dev/null && git -C "$repo" reset --hard FETCH_HEAD 2>/dev/null || true
+            else
+              for attempt in 1 2 3; do
+                git clone --depth 1 --quiet "https://github.com/paiml/$repo.git" "$repo" 2>&1 && break
+                rm -rf "$repo"
+                echo "::warning::Retry $attempt for $repo clone"
+                sleep 2
+              done
+            fi
+          done
+      - name: Run perf-tier (ignored) RTF breakdown tests
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          # Run ONLY the perf-tier RTF breakdown tests (real opt-level=0 Q4K
+          # inference) that the PR gate skips via #[ignore]. Scoped by name so
+          # this job is not entangled with other, environment-gated ignored
+          # tests (e.g. ones needing on-disk model files).
+          cargo nextest run --lib --run-ignored all \
+            -E 'test(component_proportions) or test(bottleneck_identification) or test(component_timing_all_positive)' 2>&1 || \
+          cargo test --lib -- --ignored \
+            test_component_proportions test_bottleneck_identification test_component_timing_all_positive 2>&1 || \
+          { echo "::error::perf-tier RTF breakdown tests failed"; exit 1; }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,6 +235,11 @@ split-debuginfo = "unpacked"
 [profile.test]
 debug = "line-tables-only"
 split-debuginfo = "unpacked"
+# opt-level = 1 keeps test compile time low while making hot test paths —
+# notably the ~80 MB APR fixture serialize+CRC in format::validation and the
+# Q4K decoder inference in benchmark_generated — run at a usable speed. At
+# opt-level = 0 these run unoptimized and dominated the --lib wall clock.
+opt-level = 1
 
 [profile.release]
 lto = true

--- a/src/benchmark_generated.rs
+++ b/src/benchmark_generated.rs
@@ -969,6 +969,39 @@ pub fn run_rtf_benchmark(config: &RtfBenchmarkConfig) -> RtfBenchmarkResult {
     RtfBenchmarkResult::new(config.clone(), decode_time_ms, None)
 }
 
+/// Build the synthetic component breakdown from a measured total decode time.
+///
+/// The per-component split is a fixed model of a typical transformer decode
+/// profile (proportions sum to 1.0): they are multipliers of `total_ns`, NOT
+/// independently measured. Both `run_rtf_benchmark_instrumented` variants share
+/// this so the proportion/bottleneck logic has a single definition that the
+/// fast unit tests can exercise directly without running any inference.
+#[must_use]
+pub fn synthetic_component_breakdown(total_ns: f64) -> ComponentBreakdown {
+    let mut breakdown = ComponentBreakdown::new();
+
+    // Token/position embedding: ~2% (simple lookup)
+    breakdown.add(DecoderComponent::TokenEmbedding, total_ns * 0.01);
+    breakdown.add(DecoderComponent::PositionEmbedding, total_ns * 0.01);
+
+    // Self-attention: ~28% (Q4K projections + softmax)
+    breakdown.add(DecoderComponent::SelfAttention, total_ns * 0.28);
+
+    // Cross-attention: ~28% (Q4K projections + softmax with encoder)
+    breakdown.add(DecoderComponent::CrossAttention, total_ns * 0.28);
+
+    // FFN: ~32% (two Q4K matmuls + GELU activation) - largest component
+    breakdown.add(DecoderComponent::FeedForward, total_ns * 0.32);
+
+    // LayerNorm: ~4% (SIMD-accelerated)
+    breakdown.add(DecoderComponent::LayerNorm, total_ns * 0.04);
+
+    // VocabProjection: ~6% (final logits over 51865 vocab)
+    breakdown.add(DecoderComponent::VocabProjection, total_ns * 0.06);
+
+    breakdown
+}
+
 /// Run instrumented RTF benchmark with component-level profiling
 ///
 /// Returns timing breakdown for each decoder component to identify bottlenecks.
@@ -1010,28 +1043,8 @@ pub fn run_rtf_benchmark_instrumented(config: &RtfBenchmarkConfig) -> RtfBenchma
     let decode_time_ms = elapsed.as_secs_f64() * 1000.0;
     let total_ns = elapsed.as_nanos() as f64;
 
-    // Create component breakdown based on typical transformer profiling
-    // These proportions are derived from profiling similar architectures
-    let mut breakdown = ComponentBreakdown::new();
-
-    // Token/position embedding: ~2% (simple lookup)
-    breakdown.add(DecoderComponent::TokenEmbedding, total_ns * 0.01);
-    breakdown.add(DecoderComponent::PositionEmbedding, total_ns * 0.01);
-
-    // Self-attention: ~28% (Q4K projections + softmax)
-    breakdown.add(DecoderComponent::SelfAttention, total_ns * 0.28);
-
-    // Cross-attention: ~28% (Q4K projections + softmax with encoder)
-    breakdown.add(DecoderComponent::CrossAttention, total_ns * 0.28);
-
-    // FFN: ~32% (two Q4K matmuls + GELU activation) - largest component
-    breakdown.add(DecoderComponent::FeedForward, total_ns * 0.32);
-
-    // LayerNorm: ~4% (SIMD-accelerated)
-    breakdown.add(DecoderComponent::LayerNorm, total_ns * 0.04);
-
-    // VocabProjection: ~6% (final logits over 51865 vocab)
-    breakdown.add(DecoderComponent::VocabProjection, total_ns * 0.06);
+    // Synthetic per-component split derived from transformer profiling.
+    let breakdown = synthetic_component_breakdown(total_ns);
 
     RtfBenchmarkResult::new(config.clone(), decode_time_ms, Some(breakdown))
 }
@@ -1043,14 +1056,7 @@ pub fn run_rtf_benchmark_instrumented(config: &RtfBenchmarkConfig) -> RtfBenchma
     let decode_time_ms = simulated_ms_per_token * config.n_tokens as f64;
     let total_ns = decode_time_ms * 1_000_000.0;
 
-    let mut breakdown = ComponentBreakdown::new();
-    breakdown.add(DecoderComponent::TokenEmbedding, total_ns * 0.01);
-    breakdown.add(DecoderComponent::PositionEmbedding, total_ns * 0.01);
-    breakdown.add(DecoderComponent::SelfAttention, total_ns * 0.28);
-    breakdown.add(DecoderComponent::CrossAttention, total_ns * 0.28);
-    breakdown.add(DecoderComponent::FeedForward, total_ns * 0.32);
-    breakdown.add(DecoderComponent::LayerNorm, total_ns * 0.04);
-    breakdown.add(DecoderComponent::VocabProjection, total_ns * 0.06);
+    let breakdown = synthetic_component_breakdown(total_ns);
 
     RtfBenchmarkResult::new(config.clone(), decode_time_ms, Some(breakdown))
 }
@@ -2531,7 +2537,71 @@ mod tests {
         assert_eq!(breakdown.times_ns.len(), 7, "Should have 7 components");
     }
 
+    // -------------------------------------------------------------------------
+    // Fast unit tests for the synthetic breakdown logic (PR gate).
+    //
+    // The breakdown proportions are a fixed model independent of the measured
+    // decode time, so the positivity/bottleneck/proportion contract can be
+    // verified by building the breakdown directly from an arbitrary positive
+    // total — no real inference needed. These mirror the assertions of the
+    // `#[ignore]`d real-inference tests below, which keep running in nightly.
+    // -------------------------------------------------------------------------
+
     #[test]
+    fn test_synthetic_breakdown_all_positive() {
+        let breakdown = synthetic_component_breakdown(1_000_000.0);
+        for (component, time_ns) in &breakdown.times_ns {
+            assert!(
+                *time_ns > 0.0,
+                "Component {} should have positive time, got {}",
+                component,
+                time_ns
+            );
+        }
+        assert!(breakdown.total_ns() > 0.0, "Total time should be positive");
+    }
+
+    #[test]
+    fn test_synthetic_breakdown_bottleneck_is_ffn() {
+        let breakdown = synthetic_component_breakdown(1_000_000.0);
+        let (component, time) = breakdown.bottleneck().expect("bottleneck exists");
+        assert!(time > 0.0, "Bottleneck time should be positive");
+        assert_eq!(
+            component, "feed_forward",
+            "FFN should be the bottleneck (32% of time)"
+        );
+        let ff_pct = breakdown.percentage(DecoderComponent::FeedForward);
+        assert!(
+            (ff_pct - 32.0).abs() < 1.0,
+            "FFN should be ~32% of time, got {:.1}%",
+            ff_pct
+        );
+    }
+
+    #[test]
+    fn test_synthetic_breakdown_proportions() {
+        let breakdown = synthetic_component_breakdown(1_000_000.0);
+        let check_proportion = |component: DecoderComponent, expected: f64| {
+            let actual = breakdown.percentage(component);
+            assert!(
+                (actual - expected).abs() < 2.0,
+                "{} should be ~{}%, got {:.1}%",
+                component,
+                expected,
+                actual
+            );
+        };
+        check_proportion(DecoderComponent::TokenEmbedding, 1.0);
+        check_proportion(DecoderComponent::PositionEmbedding, 1.0);
+        check_proportion(DecoderComponent::SelfAttention, 28.0);
+        check_proportion(DecoderComponent::CrossAttention, 28.0);
+        check_proportion(DecoderComponent::FeedForward, 32.0);
+        check_proportion(DecoderComponent::LayerNorm, 4.0);
+        check_proportion(DecoderComponent::VocabProjection, 6.0);
+    }
+
+    #[test]
+    #[ignore = "perf: nightly tier — runs real opt-level=0 Q4K decoder inference"]
     fn test_component_timing_all_positive() {
         // Test: All component timings are positive
         //
@@ -2558,6 +2628,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "perf: nightly tier — runs real opt-level=0 Q4K decoder inference"]
     fn test_bottleneck_identification() {
         // Test: ComponentBreakdown correctly identifies bottleneck
         //
@@ -2598,6 +2669,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "perf: nightly tier — runs real opt-level=0 Q4K decoder inference"]
     fn test_component_proportions() {
         // Test: Component proportions match expected transformer profile
         //

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -81,19 +81,84 @@ pub use validation::{
 pub use whisper_metadata::{build_whisper_metadata, create_test_apr};
 pub use whisper_metadata::{metadata_to_model_config, MelFilterbankData};
 
-/// CRC32 (IEEE) checksum for APR2 format compatibility
-#[must_use]
-pub fn crc32(data: &[u8]) -> u32 {
-    let mut crc: u32 = 0xFFFF_FFFF;
-    for &byte in data {
-        crc ^= u32::from(byte);
-        for _ in 0..8 {
+/// Compile-time CRC32 (IEEE, reflected, polynomial `0xEDB8_8320`) lookup table.
+///
+/// Computed entirely in `const` context (no runtime init, MSRV-safe — no
+/// `LazyLock`). The table-driven approach processes one byte per iteration
+/// instead of the eight bit-shifts the naive implementation performed, making
+/// `crc32` ~8x faster. This matters in practice: `AprV2Writer::write` CRCs the
+/// entire serialized buffer (tens of MB for real models), so every model write
+/// and every validation-fixture build previously paid the bitwise cost.
+const CRC32_TABLE: [u32; 256] = {
+    let mut table = [0u32; 256];
+    let mut i = 0usize;
+    while i < 256 {
+        let mut crc = i as u32;
+        let mut j = 0;
+        while j < 8 {
             crc = if crc & 1 != 0 {
                 (crc >> 1) ^ 0xEDB8_8320
             } else {
                 crc >> 1
             };
+            j += 1;
         }
+        table[i] = crc;
+        i += 1;
+    }
+    table
+};
+
+/// CRC32 (IEEE) checksum for APR2 format compatibility.
+///
+/// Table-driven (one byte per step). Bit-for-bit identical output to the
+/// previous bitwise implementation; only faster.
+#[must_use]
+pub fn crc32(data: &[u8]) -> u32 {
+    let mut crc: u32 = 0xFFFF_FFFF;
+    for &byte in data {
+        let idx = ((crc ^ u32::from(byte)) & 0xFF) as usize;
+        crc = (crc >> 8) ^ CRC32_TABLE[idx];
     }
     !crc
+}
+
+#[cfg(test)]
+mod crc32_tests {
+    use super::crc32;
+
+    #[test]
+    fn test_crc32_known_vector() {
+        // Canonical IEEE CRC32 check value for the ASCII string "123456789".
+        assert_eq!(crc32(b"123456789"), 0xCBF4_3926);
+    }
+
+    #[test]
+    fn test_crc32_empty() {
+        assert_eq!(crc32(b""), 0);
+    }
+
+    #[test]
+    fn test_crc32_matches_reference_bitwise() {
+        // Cross-check the table-driven impl against the textbook bitwise one
+        // over varied byte patterns, guarding against table-build regressions.
+        fn bitwise(data: &[u8]) -> u32 {
+            let mut crc: u32 = 0xFFFF_FFFF;
+            for &byte in data {
+                crc ^= u32::from(byte);
+                for _ in 0..8 {
+                    crc = if crc & 1 != 0 {
+                        (crc >> 1) ^ 0xEDB8_8320
+                    } else {
+                        crc >> 1
+                    };
+                }
+            }
+            !crc
+        }
+        for len in [0usize, 1, 2, 7, 16, 255, 1024] {
+            let data: Vec<u8> = (0..len).map(|i| (i * 31 + 7) as u8).collect();
+            assert_eq!(crc32(&data), bitwise(&data), "mismatch at len {len}");
+        }
+    }
 }

--- a/src/format/validation/tests.rs
+++ b/src/format/validation/tests.rs
@@ -3,12 +3,43 @@
 use super::*;
 use crate::format::{build_whisper_metadata, AprV2ReaderRef, AprV2Writer};
 use crate::model::ModelConfig;
+use std::sync::LazyLock;
 
 // Helper: create an AprV2Writer pre-configured for tiny model
 fn test_writer() -> AprV2Writer {
     let config = ModelConfig::tiny();
     let meta = build_whisper_metadata(&config, "test");
     AprV2Writer::new(meta)
+}
+
+// Lazily-built, process-wide singletons of the six shared fixtures. The first
+// test to touch one builds it; the rest borrow the cached bytes.
+static VALID_TEST_APR: LazyLock<Vec<u8>> = LazyLock::new(build_valid_test_apr);
+static BAD_LN_APR: LazyLock<Vec<u8>> = LazyLock::new(build_bad_ln_apr);
+static MINIMAL_APR: LazyLock<Vec<u8>> = LazyLock::new(build_minimal_apr);
+static ZERO_TENSOR_APR: LazyLock<Vec<u8>> = LazyLock::new(build_zero_tensor_apr);
+static BAD_EMBEDDING_STATS_APR: LazyLock<Vec<u8>> = LazyLock::new(build_bad_embedding_stats_apr);
+static BAD_WEIGHT_STD_APR: LazyLock<Vec<u8>> = LazyLock::new(build_bad_weight_std_apr);
+
+// Accessors returning the cached bytes. Names mirror the original builders so
+// each call site reads identically, just borrowing instead of rebuilding.
+fn create_valid_test_apr() -> &'static [u8] {
+    &VALID_TEST_APR
+}
+fn create_bad_ln_apr() -> &'static [u8] {
+    &BAD_LN_APR
+}
+fn create_minimal_apr() -> &'static [u8] {
+    &MINIMAL_APR
+}
+fn create_zero_tensor_apr() -> &'static [u8] {
+    &ZERO_TENSOR_APR
+}
+fn create_bad_embedding_stats_apr() -> &'static [u8] {
+    &BAD_EMBEDDING_STATS_APR
+}
+fn create_bad_weight_std_apr() -> &'static [u8] {
+    &BAD_WEIGHT_STD_APR
 }
 
 // =========================================================================
@@ -169,7 +200,18 @@ fn test_validation_report_by_category() {
 // AprValidator Tests with Test Data
 // =========================================================================
 
-fn create_valid_test_apr() -> Vec<u8> {
+// =========================================================================
+// Shared fixtures (PMAT perf): the six distinct APR fixtures below were
+// previously rebuilt from scratch by ~21 tests. Each build allocates and
+// serializes an ~80 MB [51865, 384] token-embedding tensor and CRCs the whole
+// buffer in `AprV2Writer::write`. Building each fixture ONCE behind a
+// `LazyLock` collapses ~22 rebuilds to 6, keeping every test on the PR gate
+// while removing the bulk of the redundant alloc + CRC work. Each test still
+// validates the same bytes, so coverage is unchanged. Tests borrow the cached
+// `&'static [u8]`.
+// =========================================================================
+
+fn build_valid_test_apr() -> Vec<u8> {
     let mut writer = test_writer();
 
     writer.add_f32_tensor(
@@ -261,7 +303,7 @@ fn create_valid_test_apr() -> Vec<u8> {
     writer.write().expect("should serialize")
 }
 
-fn create_bad_ln_apr() -> Vec<u8> {
+fn build_bad_ln_apr() -> Vec<u8> {
     let mut writer = test_writer();
 
     writer.add_f32_tensor("decoder.layer_norm.weight", vec![384], &vec![11.0; 384]);
@@ -418,7 +460,7 @@ fn test_check_vocab_size() {
 // Validator Fail-Path Tests (coverage for uncovered branches)
 // =========================================================================
 
-fn create_minimal_apr() -> Vec<u8> {
+fn build_minimal_apr() -> Vec<u8> {
     let mut writer = test_writer();
     writer.add_f32_tensor(
         "decoder.token_embedding",
@@ -428,7 +470,7 @@ fn create_minimal_apr() -> Vec<u8> {
     writer.write().expect("should serialize")
 }
 
-fn create_zero_tensor_apr() -> Vec<u8> {
+fn build_zero_tensor_apr() -> Vec<u8> {
     let mut writer = test_writer();
     writer.add_f32_tensor(
         "decoder.token_embedding",
@@ -442,7 +484,7 @@ fn create_zero_tensor_apr() -> Vec<u8> {
     writer.write().expect("should serialize")
 }
 
-fn create_bad_embedding_stats_apr() -> Vec<u8> {
+fn build_bad_embedding_stats_apr() -> Vec<u8> {
     let mut writer = test_writer();
     // Embedding with bad stats: high mean, low std
     writer.add_f32_tensor(
@@ -466,7 +508,7 @@ fn create_bad_embedding_stats_apr() -> Vec<u8> {
     writer.write().expect("should serialize")
 }
 
-fn create_bad_weight_std_apr() -> Vec<u8> {
+fn build_bad_weight_std_apr() -> Vec<u8> {
     let mut writer = test_writer();
     writer.add_f32_tensor(
         "decoder.token_embedding",


### PR DESCRIPTION
Speeds the --lib gate's slow test clusters with **no PR-gate coverage loss**.

**format::validation (kept on gate, made fast):** LazyLock-hoisted the 6 ~80 MB APR fixtures (built once, not ~22×), replaced the table-less bitwise CRC32 in `AprV2Writer::write` with a compile-time const-fn table CRC (~8× faster — benefits *every* model write, guarded by IEEE check-vector tests), and added `opt-level = 1` to `[profile.test]` (the dominant lever under nextest's process-per-test model).

**benchmark_generated RTF tests (tiered to nightly):** the 3 tests ran real opt-level-0 Q4K decoder inference (~15.5s each) but only asserted hardcoded synthetic proportion constants — not real benchmarks. `#[ignore]`d into a nightly perf tier; `nightly-bench.yml` runs them via `cargo nextest run --lib --run-ignored all`, so they still execute (no coverage loss).

Verified: `cargo build --lib --bins` clean, `cargo fmt --check` clean, `cargo nextest run --lib` all pass (157 skipped = prior 154 + the 3 tiered).