### PR TITLE
fix(cli): folder discovery uses decoder's extension source of truth (#17)

### DIFF
--- a/contracts/folder-discovery-v1.yaml
+++ b/contracts/folder-discovery-v1.yaml
@@ -1,0 +1,64 @@
+metadata:
+  version: "1.0.0"
+  author: "Sovereign AI Stack"
+  description: "Folder/batch discovery contract: discovery accepts exactly the formats the decoder supports (no silent skips)"
+  crate: "whisper-apr"
+  references:
+    - "whisper.apr issue #17 (folder-transcription extension drift: .mov/.mkv/.avi/.opus silently skipped)"
+    - "src/audio/decode.rs SUPPORTED_EXTENSIONS — single source of truth"
+
+equations:
+  folder_discovery_set:
+    formula: "discoverable(ext) <=> is_supported_extension(ext)"
+    domain: "ext in lowercase file extensions"
+    invariants:
+      - "Folder discovery recognizes an extension iff the single-file decoder supports it"
+      - "No supported decode format is silently dropped from batch/folder runs"
+      - "Matching is case-insensitive (extensions are lowercased before comparison)"
+
+proof_obligations:
+  - type: invariant
+    property: "Discovery matches decoder support set"
+    formal: "forall ext in SUPPORTED_EXTENSIONS: has_folder_audio_extension(\"clip.\"+ext) == true"
+    applies_to: all
+  - type: invariant
+    property: "No false positives on non-audio extensions"
+    formal: "has_folder_audio_extension(\"notes.txt\") == false"
+    applies_to: all
+  - type: invariant
+    property: "Case-insensitive parity"
+    formal: "has_folder_audio_extension(\"a.MOV\") == has_folder_audio_extension(\"a.mov\")"
+    applies_to: all
+
+falsification_tests:
+  - id: FALSIFY-FDRIFT-001
+    rule: "Discovery covers every decoder-supported extension"
+    test: "test_has_folder_audio_extension_covers_all_decoder_formats"
+    prediction: "verified"
+    if_fails: "A decode-supported format (e.g. .mov/.mkv/.avi/.opus) is silently skipped in batch mode (issue #17 regression)"
+  - id: FALSIFY-FDRIFT-002
+    rule: "A folder with mixed .mov + .wav yields both"
+    test: "test_discover_folder_recursive_finds_mov_and_wav"
+    prediction: "verified"
+    if_fails: "Folder discovery drops .mov files, losing ~20% of mixed corpora"
+  - id: FALSIFY-FDRIFT-003
+    rule: "Previously-dropped formats now discovered (incl. uppercase)"
+    test: "test_has_folder_audio_extension_previously_dropped_formats"
+    prediction: "verified"
+    if_fails: ".mov/.mkv/.avi/.opus or their uppercase forms still skipped"
+  - id: FALSIFY-FDRIFT-004
+    rule: "Original eight formats still match; non-audio rejected"
+    test: "test_has_folder_audio_extension_original_eight_still_match"
+    prediction: "verified"
+    if_fails: "Widening discovery regressed the original list or now accepts non-audio files"
+
+qa_gate:
+  id: QA-FOLDER-DISCOVERY
+  name: "folder discovery extension parity contract"
+  min_coverage: 0.90
+  max_complexity: 10
+  required_tests:
+    - test_has_folder_audio_extension_covers_all_decoder_formats
+    - test_discover_folder_recursive_finds_mov_and_wav
+    - test_has_folder_audio_extension_previously_dropped_formats
+    - test_has_folder_audio_extension_original_eight_still_match

--- a/src/cli/commands_generated.rs
+++ b/src/cli/commands_generated.rs
@@ -1067,18 +1067,15 @@ fn is_symlink_via_metadata(path: &Path) -> bool {
 
 /// Check if a path has a recognized audio file extension for folder discovery.
 ///
-/// This is the extension list used by `discover_folder_recursive`. It intentionally
-/// matches the inline list from the original implementation (without `mkv`).
+/// Delegates to the single source of truth in [`crate::audio::decode`] so folder
+/// discovery and single-file decode can never drift apart. Previously this kept a
+/// hand-maintained list that silently dropped `.mov/.mkv/.avi/.opus`, causing batch
+/// runs to skip files the decoder fully supports (issue #17). `is_supported_extension`
+/// already lowercases, so matching is case-insensitive.
 fn has_folder_audio_extension(path: &Path) -> bool {
     path.extension()
         .and_then(|e| e.to_str())
-        .map(|e| e.to_lowercase())
-        .map_or(false, |ext| {
-            matches!(
-                ext.as_str(),
-                "wav" | "mp3" | "flac" | "ogg" | "m4a" | "mp4" | "webm" | "aac"
-            )
-        })
+        .map_or(false, crate::audio::decode::is_supported_extension)
 }
 
 /// Classify a single directory entry as audio file, subdirectory, or ignored.
@@ -5953,6 +5950,82 @@ mod tests {
         // Recursive
         let files_rec = discover_audio_files(&inputs, true, None);
         assert_eq!(files_rec.len(), 3, "Recursive should find all files");
+    }
+
+    #[test]
+    fn test_has_folder_audio_extension_covers_all_decoder_formats() {
+        // FALSIFY-FDRIFT-001 (issue #17 batch residue): folder discovery must
+        // recognize every extension the single-file decoder supports. Previously
+        // .mov/.mkv/.avi/.opus were silently dropped from batch/folder runs even
+        // though src/audio/decode.rs decodes them fine.
+        for ext in crate::audio::decode::SUPPORTED_EXTENSIONS {
+            let path = PathBuf::from(format!("clip.{ext}"));
+            assert!(
+                has_folder_audio_extension(&path),
+                "folder discovery dropped .{ext} but the decoder supports it (silent data loss)"
+            );
+        }
+    }
+
+    #[test]
+    fn test_has_folder_audio_extension_previously_dropped_formats() {
+        // The four formats that #17 reported as vanishing from folder runs.
+        for ext in ["mov", "mkv", "avi", "opus"] {
+            assert!(
+                has_folder_audio_extension(&PathBuf::from(format!("a.{ext}"))),
+                ".{ext} must be discovered in folder mode"
+            );
+            // Case-insensitive (is_supported_extension lowercases).
+            assert!(
+                has_folder_audio_extension(&PathBuf::from(format!("a.{}", ext.to_uppercase()))),
+                ".{} (uppercase) must be discovered in folder mode",
+                ext.to_uppercase()
+            );
+        }
+    }
+
+    #[test]
+    fn test_has_folder_audio_extension_original_eight_still_match() {
+        // Regression guard: the pre-fix list must remain recognized.
+        for ext in ["wav", "mp3", "flac", "ogg", "m4a", "mp4", "webm", "aac"] {
+            assert!(
+                has_folder_audio_extension(&PathBuf::from(format!("a.{ext}"))),
+                ".{ext} must still be discovered"
+            );
+        }
+        // Non-audio extensions are still rejected.
+        assert!(!has_folder_audio_extension(&PathBuf::from("notes.txt")));
+        assert!(!has_folder_audio_extension(&PathBuf::from("noext")));
+    }
+
+    #[test]
+    fn test_discover_folder_recursive_finds_mov_and_wav() {
+        // FALSIFY-FDRIFT-002: a folder containing a .mov + .wav must yield BOTH.
+        use tempfile::TempDir;
+
+        let temp = TempDir::new().expect("create temp dir");
+        let dir = temp.path();
+        fs::write(dir.join("clip.mov"), b"").expect("write clip.mov");
+        fs::write(dir.join("voice.wav"), b"").expect("write voice.wav");
+
+        let files = discover_folder_audio_files(dir, false);
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            files.len(),
+            2,
+            "both .mov and .wav must be discovered: {names:?}"
+        );
+        assert!(
+            names.contains(&"clip.mov".to_string()),
+            "missing clip.mov: {names:?}"
+        );
+        assert!(
+            names.contains(&"voice.wav".to_string()),
+            "missing voice.wav: {names:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem (issue #17, live batch-mode residue)

`has_folder_audio_extension()` in `src/cli/commands_generated.rs` kept a hand-maintained `matches!` list — `wav|mp3|flac|ogg|m4a|mp4|webm|aac` — that **deliberately dropped `mkv/mov/avi/opus`**. Meanwhile `src/audio/decode.rs` (`SUPPORTED_EXTENSIONS`) already lists all 12 formats and single-file decode handles them. Result: in batch/folder runs, `.mov/.mkv/.avi/.opus` files were **silently skipped** — a silent-data-loss class (~20% of `.mov` files vanish from mixed corpora per #17).

## Fix

Replace the parallel list with a delegation to the single source of truth:

```rust
fn has_folder_audio_extension(path: &Path) -> bool {
    path.extension()
        .and_then(|e| e.to_str())
        .map_or(false, crate::audio::decode::is_supported_extension)
}
```

`is_supported_extension` already lowercases, so matching stays case-insensitive. Widening discovery is **additive** — decode already supports these formats, so blast radius is small.

## Tests (TDD — written failing first, then fixed)

- `test_has_folder_audio_extension_covers_all_decoder_formats` — discovery recognizes every `SUPPORTED_EXTENSIONS` entry.
- `test_has_folder_audio_extension_previously_dropped_formats` — `.mov/.mkv/.avi/.opus` (+ uppercase) now discovered.
- `test_has_folder_audio_extension_original_eight_still_match` — original 8 still match; non-audio rejected.
- `test_discover_folder_recursive_finds_mov_and_wav` — temp dir with `.mov` + `.wav` yields **both**.

## Provable contract

`contracts/folder-discovery-v1.yaml` (`FALSIFY-FDRIFT-001..004`): folder-discovery set == decoder support set; no supported format silently dropped.

## Verification

- `cargo build -p whisper-apr` — clean
- `cargo test -p whisper-apr --lib` — **3045 passed, 0 failed**
- `cargo clippy -p whisper-apr --lib --bins -- -D warnings` (the CI gate's clippy args) — clean
- `cargo fmt --all -- --check` — clean

Note: the repo's `--all-targets` clippy has 893 pre-existing errors in non-shipped scaffolding (documented in `.github/workflows/ci.yml`, tracked in #54); the CI merge gate uses `--lib --bins`, which passes.

Closes the batch-folder residue of #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)