### PR TITLE
ci(nightly): hermetic builds — keep committed Cargo.lock, build --locked

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,8 +77,9 @@ jobs:
           # Fix apr-cli version: 0.3 doesn't exist on crates.io, only 0.4.x
           sed -i.bak 's|apr-cli = { version = "0.3"|apr-cli = { version = "0.4"|g' Cargo.toml
           rm -f Cargo.toml.bak
-          # Regenerate lockfile (old one has path-sourced entries from [patch])
-          rm -f Cargo.lock
+          # Keep the committed Cargo.lock: the build below runs with --locked so the
+          # nightly fails loudly on any unexpected lockfile drift instead of silently
+          # resolving new dependency versions every run (hermetic, reproducible builds).
           echo "=== Patched Cargo.toml dependency sections ==="
           grep -n 'aprender\|apr-cli\|\[patch' Cargo.toml || true
           echo "=== .cargo/config.toml removed ==="
@@ -99,8 +100,9 @@ jobs:
           # Fix apr-cli version: 0.3 doesn't exist on crates.io, only 0.4.x
           $content = $content -replace 'apr-cli = \{ version = "0\.3"', 'apr-cli = { version = "0.4"'
           Set-Content Cargo.toml -Value $content.TrimEnd() -NoNewline
-          # Regenerate lockfile (old one has path-sourced entries from [patch])
-          Remove-Item Cargo.lock -ErrorAction SilentlyContinue
+          # Keep the committed Cargo.lock: the build below runs with --locked so the
+          # nightly fails loudly on any unexpected lockfile drift instead of silently
+          # resolving new dependency versions every run (hermetic, reproducible builds).
           Write-Host "=== Patched Cargo.toml dependency sections ==="
           Select-String -Path Cargo.toml -Pattern 'aprender|apr-cli|\[patch'
 
@@ -119,11 +121,11 @@ jobs:
         if: matrix.cross
         env:
           CROSS_NO_WARNINGS: "0"
-        run: cross build --release --target ${{ matrix.target }} --features cli
+        run: cross build --locked --release --target ${{ matrix.target }} --features cli
 
       - name: Build
         if: ${{ !matrix.cross }}
-        run: cargo build --release --target ${{ matrix.target }} --features cli
+        run: cargo build --locked --release --target ${{ matrix.target }} --features cli
 
       - name: Package (unix)
         if: matrix.target != 'x86_64-pc-windows-msvc'


### PR DESCRIPTION
## Summary

The nightly workflow ran `rm -f Cargo.lock` before each build, letting dependencies float to new versions every run and defeating reproducibility. The manifest is now standalone (crates.io versions, `[patch.crates-io]` commented out), so the committed `Cargo.lock` already resolves cleanly and the lockfile-regeneration step is obsolete.

This change makes the nightly hermetic:

- Drop `rm -f Cargo.lock` (unix) and `Remove-Item Cargo.lock` (windows) from the standalone-patch steps; keep the committed lockfile in place.
- Add `--locked` to the `cargo build` and `cross build` invocations so the nightly **fails loudly** on any unexpected lockfile drift instead of silently resolving new versions. A deliberate refresh should be a separate, explicit `cargo update` step — never an unconditional `rm`.

## Verification

- `cargo metadata --locked` is green against the committed `Cargo.lock` (lock/manifest in sync).
- Negative test: injecting a stale lock (bumping `aprender` to a version the lock doesn't satisfy) makes `--locked` exit `101` with `cannot update the lock file ... because --locked was passed` — confirms the loud-failure behavior.
- The existing standalone patch-sed steps are no-ops on the current manifest (verified by replaying them and diffing), so `--locked` passes post-patch in CI.
- Real CI clippy scope (`--lib --bins`, per `ci.yml`) and `cargo fmt --check` are both green.

## Blast radius

Workflow-only change. No source files touched.

Refs PMAT-034

🤖 Generated with [Claude Code](https://claude.com/claude-code)