### PR TITLE
fix(ci): un-red Nightly Bench — grant provenance perms + shipped-artifacts lint scope (Refs PMAT-178)

### DIFF
--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -7,14 +7,27 @@ on:
 concurrency:
   group: bench-${{ github.ref }}
   cancel-in-progress: true
+# PMAT-178: the called sovereign-ci.yml's provenance job requests
+# id-token/attestations — a caller pinned to `contents: read` alone cannot
+# grant that elevation, and GitHub refuses to START the run (startup_failure
+# nightly since 2026-06-25, introduced by c024283 adding this block).
+# ci.yml (no permissions block) never hit this because the default grant
+# covers it. Least-privilege is kept: only what provenance needs is added.
 permissions:
   contents: read
+  id-token: write
+  attestations: write
 jobs:
   bench:
     uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
     with:
       repo: ${{ github.event.repository.name }}
       run_benchmarks: true
+      # Same shipped-artifacts lint scope as ci.yml — without it the nightly
+      # linted --all-targets and failed on the ~893 test/bench-scaffolding
+      # pedantic lints ci.yml deliberately carves out.
+      # Tracked: https://github.com/paiml/whisper.apr/issues/54 (PMAT-158)
+      clippy_args: "--lib --bins"
     secrets: inherit
 
   # Perf-tier unit tests: the real-inference RTF breakdown tests in


### PR DESCRIPTION
## Root cause (five whys)

Nightly Bench: `startup_failure` every night since 2026-06-25.

1. GitHub refused to **start** the run → 2. caller grants `permissions: contents: read` only, but the called `sovereign-ci.yml` provenance job requests `id-token: write` + `attestations: write` → 3. that block was added in c024283 (#62, 2026-06-24) as least-privilege hardening → 4. ci.yml never hit it (no permissions block → default grant) → 5. **caller/callee permission contract wasn't checked when hardening the caller**.

## Fix

- Grant exactly what provenance needs (`id-token`, `attestations`) — least-privilege kept.
- Pass `clippy_args: "--lib --bins"` like ci.yml: pre-startup_failure, `bench / lint` failed on the ~893 test/bench scaffolding pedantic lints ci.yml deliberately carves out (#54, PMAT-158).

## What about the security failures? (already fixed)

Pre-06-25 the run also failed `bench / security`: RUSTSEC-2026-0185 (quinn-proto) + RUSTSEC-2026-0104 (rustls-webpki). Main's lock now carries patched 0.11.15 / 0.103.13 and `ci / security` is green.

**PMAT-178 premise falsified**: openssl-sys was never the red cause — audit flags were quinn/webpki (fixed); openssl enters only as non-flagged transitive weight via registry aprender-stack deps (hf-hub/reqwest native-tls). Purge remains a fleet-policy nicety, not an un-red requirement.

## Validation

`workflow_dispatch` fired on this branch — startup succeeding (vs 7 nights of startup_failure) + lint/security green is the proof; see the linked run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)