### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `make install` prevents duplicate binary installs: removes stale copies outside `~/.cargo/bin/` before
   install, verifies single binary post-install (exits non-zero if duplicates detected).
 
+## [0.3.1] - 2026-07-05
+
+### Changed
+- **Dependencies consolidated onto the aprender monorepo.** `trueno` → `aprender-compute`,
+  `trueno-gpu` → `aprender-gpu`, `realizar` → `aprender-serve`, and `provable-contracts-macros`
+  → `aprender-contracts-macros`, all unified at `0.51`. Library names are unchanged, so there is
+  no source or public-API change. Removes three duplicate `trueno` versions and the legacy `0.29`
+  line.
+- `hf-hub` now uses the `ureq`/rustls backend (`default-features = false, features = ["ureq"]`),
+  dropping `reqwest`, `native-tls`, and `openssl` from the dependency tree.
+
+### Removed
+- **`apr-cli` dependency dropped.** The default `cli` feature pulled it in only to proxy
+  `apr pull` / `apr ls`, but it transitively dragged in ~230 crates (batuta/orchestrate →
+  arrow+parquet, tonic, axum, rusqlite, opentelemetry, reqwest, a wgpu stack, and the `quick-xml`
+  advisories). `apr pull` / `apr ls` are reimplemented on the in-tree `ModelDownloader` (new
+  `cli::apr_commands::model_pull` module) under a provable-contracts contract with offline
+  falsification tests. Net effect: `Cargo.lock` **809 → 567** crates.
+
+### Fixed
+- Eliminated the `quick-xml` `RUSTSEC-2026-0194` / `RUSTSEC-2026-0195` advisories at the source
+  (they arrived transitively via `apr-cli`), rather than suppressing them in `audit.toml`.
+- Removed `panic = "abort"` from the release profile, restoring stack unwinding in release builds.
+
 ## [0.2.2] - 2025-01-26
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "whisper-apr"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes-gcm",
  "aprender-compute",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whisper-apr"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.75"
 # PMAT-158 / issue #54: disable auto-discovery of the 104 ad-hoc debug examples


### PR DESCRIPTION
Release **v0.3.1** — ships the aprender-monorepo dependency consolidation from #71.

- Version bump `0.3.0 → 0.3.1` (patch; no public library API change)
- CHANGELOG `[0.3.1]` entry
- `Cargo.lock` version sync

Tagging `v0.3.1` after merge triggers the Release workflow → GitHub release + crates.io publish (OIDC Trusted Publishing) + cross-compiled binaries.

Pre-flight verified: `cargo publish --dry-run` clean (all deps resolve from crates.io at 0.51.0), 2904 tests, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)