### PR TITLE
fix(wasm): gate rayon in simd so wasm/minimal builds compile — v0.3.2

### DIFF
--- a/.pmat/baseline.json
+++ b/.pmat/baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "3.24.2",
-  "created_at": "2026-07-05T13:44:54.837236151Z",
+  "created_at": "2026-07-05T19:35:21.266984896Z",
   "git_context": null,
   "files": {
     "./benches/cli_benchmarks.rs": {
@@ -15141,48 +15141,48 @@
     },
     "./src/cli/apr_commands/mod.rs": {
       "content_hash": [
-        5,
-        61,
-        113,
-        110,
+        242,
+        64,
+        240,
+        101,
+        78,
+        211,
+        43,
+        189,
+        52,
+        238,
+        36,
+        213,
+        9,
         169,
-        204,
-        121,
-        176,
-        145,
-        159,
-        205,
-        51,
-        83,
-        142,
-        26,
-        10,
-        191,
+        174,
+        39,
+        226,
+        196,
         72,
-        166,
-        207,
-        88,
-        228,
-        47,
+        212,
+        54,
+        154,
+        44,
+        140,
+        233,
+        160,
         161,
-        37,
-        7,
-        35,
-        25,
-        190,
-        48,
-        4,
-        70
+        125,
+        72,
+        146,
+        206,
+        200
       ],
       "score": {
         "structural_complexity": 0.0,
         "semantic_complexity": 20.0,
-        "duplication_ratio": 17.608183,
+        "duplication_ratio": 17.688604,
         "coupling_score": 15.0,
         "doc_coverage": 10.0,
         "consistency_score": 10.0,
         "entropy_score": 5.0,
-        "total": 77.608185,
+        "total": 77.68861,
         "grade": "B",
         "confidence": 1.0,
         "language": "Rust",
@@ -15194,15 +15194,15 @@
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Found 87 duplicate code patterns"
+            "issue": "Found 81 duplicate code patterns"
           },
           {
             "source_metric": "Duplication",
-            "amount": 2.3918173,
+            "amount": 2.3113964,
             "applied_to": [
               "Duplication"
             ],
-            "issue": "Code duplication: 12.0%"
+            "issue": "Code duplication: 11.6%"
           },
           {
             "source_metric": "StructuralComplexity",
@@ -15219,6 +15219,85 @@
               "StructuralComplexity"
             ],
             "issue": "High cyclomatic complexity: 176"
+          }
+        ],
+        "critical_defects_count": 0,
+        "has_critical_defects": false,
+        "has_contract_coverage": false
+      },
+      "components": {
+        "complexity_breakdown": {},
+        "duplication_sources": [],
+        "coupling_dependencies": [],
+        "doc_missing_items": [],
+        "consistency_violations": []
+      },
+      "git_context": null
+    },
+    "./src/cli/apr_commands/model_pull.rs": {
+      "content_hash": [
+        218,
+        62,
+        95,
+        113,
+        86,
+        206,
+        232,
+        102,
+        21,
+        46,
+        7,
+        115,
+        185,
+        228,
+        159,
+        76,
+        210,
+        87,
+        200,
+        230,
+        249,
+        93,
+        153,
+        40,
+        233,
+        234,
+        35,
+        147,
+        137,
+        155,
+        255,
+        110
+      ],
+      "score": {
+        "structural_complexity": 20.8,
+        "semantic_complexity": 20.0,
+        "duplication_ratio": 20.0,
+        "coupling_score": 15.0,
+        "doc_coverage": 10.0,
+        "consistency_score": 10.0,
+        "entropy_score": 5.0,
+        "total": 91.63637,
+        "grade": "AMinus",
+        "confidence": 1.0,
+        "language": "Rust",
+        "file_path": "./src/cli/apr_commands/model_pull.rs",
+        "penalties_applied": [
+          {
+            "source_metric": "Duplication",
+            "amount": 5.0,
+            "applied_to": [
+              "Duplication"
+            ],
+            "issue": "Found 15 duplicate code patterns"
+          },
+          {
+            "source_metric": "StructuralComplexity",
+            "amount": 4.2000003,
+            "applied_to": [
+              "StructuralComplexity"
+            ],
+            "issue": "High cognitive complexity: 29"
           }
         ],
         "critical_defects_count": 0,
@@ -30976,10 +31055,10 @@
     }
   },
   "summary": {
-    "total_files": 397,
-    "avg_score": 94.56858,
+    "total_files": 398,
+    "avg_score": 94.56142,
     "grade_distribution": {
-      "AMinus": 371,
+      "AMinus": 372,
       "BPlus": 5,
       "B": 13,
       "BMinus": 7,
@@ -30988,7 +31067,7 @@
     "languages": {
       "JavaScript": 16,
       "Python": 9,
-      "Rust": 366,
+      "Rust": 367,
       "TypeScript": 6
     }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `make install` prevents duplicate binary installs: removes stale copies outside `~/.cargo/bin/` before
   install, verifies single binary post-install (exits non-zero if duplicates detected).
 
+## [0.3.2] - 2026-07-05
+
+### Fixed
+- **WASM / minimal-feature builds now compile.** `cargo build --target wasm32-unknown-unknown
+  --no-default-features --features wasm` (and any `default-features = false, features = ["std"]`
+  library consumer) failed to compile because `simd::optimized::tiled_matmul_into` and
+  `simd::matrix::{matmul, matmul_with_prepacked}` called `rayon` (`current_num_threads`,
+  `into_par_iter`, `par_chunks_mut`) without `#[cfg(feature = "parallel")]` guards, but `rayon`
+  is gated behind the `parallel` feature (not implied by `std`/`wasm`). Each site now gates the
+  parallel path and adds a single-threaded serial fallback, matching the other SIMD functions.
+  (The wasm/minimal build still emits a few benign dead-code / unused-import warnings from
+  feature-gated and generated code — pre-existing and non-blocking; this release fixes the hard
+  compile *errors* that previously stopped the build entirely.)
+
+### Changed
+- `make build-wasm` now builds with `--no-default-features` (it previously used the default
+  feature set, which pulls wasm-incompatible deps — masking the breakage above).
+- Auto-download error message in `load_or_download_model` is now actionable (points to
+  `cargo install whisper-apr --features converter` or `--model-path`), and the README no longer
+  implies the default install auto-downloads models (it requires the `converter` feature, kept
+  opt-in to preserve the small default dependency tree).
+
+### Added
+- `make check-features` — a feature-matrix regression guard that compiles the crate for wasm and
+  the minimal `std`-only library config. Wired into `make tier2` so this class of feature-gating
+  regression is caught before merge (Jidoka: build quality in).
+
 ## [0.3.1] - 2026-07-05
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "whisper-apr"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aes-gcm",
  "aprender-compute",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whisper-apr"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.75"
 # PMAT-158 / issue #54: disable auto-discovery of the 104 ad-hoc debug examples

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ FAST_TEST_FILTER := -E 'not test(/encoder_forward|transcription|encode_3_second|
 .ONESHELL:
 
 .PHONY: help all build build-release build-wasm test test-fast test-doc test-property test-all
-.PHONY: lint lint-fast lint-check fmt fmt-check check clean
+.PHONY: lint lint-fast lint-check fmt fmt-check check check-features clean
 .PHONY: coverage coverage-open coverage-ci coverage-clean clean-coverage
 .PHONY: tier1 tier2 tier3 quality-gates kaizen
 .PHONY: bench bench-wasm bench-pipeline bench-regression bench-tui bench-tui-test bench-tui-render bench-tui-playbook mutants mutants-quick
@@ -49,17 +49,19 @@ tier1: ## Tier 1: Sub-second feedback for rapid iteration (ON-SAVE)
 tier2: ## Tier 2: Full test suite for commits (ON-COMMIT)
 	@echo "🔍 TIER 2: Comprehensive validation (1-5 minutes)"
 	@echo ""
-	@echo "  [1/6] Formatting check..."
+	@echo "  [1/7] Formatting check..."
 	@cargo fmt -- --check
-	@echo "  [2/6] Full clippy..."
+	@echo "  [2/7] Full clippy..."
 	@cargo clippy --all-targets --all-features --quiet -- -D warnings
-	@echo "  [3/6] All tests..."
+	@echo "  [3/7] Feature-matrix build (wasm + minimal-lib — guards feature gating)..."
+	@$(MAKE) --no-print-directory check-features
+	@echo "  [4/7] All tests..."
 	@cargo test --all-features --quiet
-	@echo "  [4/6] Property tests (full cases)..."
+	@echo "  [5/7] Property tests (full cases)..."
 	@PROPTEST_CASES=25 cargo test property_ --all-features --quiet || true
-	@echo "  [5/6] Coverage analysis..."
+	@echo "  [6/7] Coverage analysis..."
 	@$(MAKE) --no-print-directory coverage-summary 2>/dev/null || echo "    ⚠️  Run 'make coverage' for detailed report"
-	@echo "  [6/6] SATD check..."
+	@echo "  [7/7] SATD check..."
 	@! grep -rn "TODO\|FIXME\|HACK" src/ 2>/dev/null || { echo "    ⚠️  SATD comments found (Toyota Way: zero tolerance)"; }
 	@echo ""
 	@echo "✅ Tier 2 complete - Ready to commit!"
@@ -100,7 +102,7 @@ build-release: ## Build release version
 build-wasm: ## Build WASM module (requires wasm-pack)
 	@echo "🌐 Building WASM module..."
 	@command -v wasm-pack >/dev/null 2>&1 || { echo "Installing wasm-pack..."; cargo install wasm-pack; }
-	wasm-pack build --target web --features wasm
+	wasm-pack build --target web --no-default-features --features wasm
 	@echo "✅ WASM build complete: pkg/"
 
 # ============================================================================
@@ -173,6 +175,14 @@ fmt-check: ## Check formatting without modifying
 check: ## Type check the project
 	@echo "🔍 Type checking..."
 	@cargo check --all-targets --all-features
+
+check-features: ## Feature-matrix regression guard: crate must compile for wasm + minimal-lib
+	@echo "🔍 Feature matrix (no-default-features builds — parallel/rayon must be gated)..."
+	@echo "  [1/2] wasm32 (--no-default-features --features wasm)..."
+	@cargo check --target wasm32-unknown-unknown --no-default-features --features wasm
+	@echo "  [2/2] minimal library (--no-default-features --features std)..."
+	@cargo check --no-default-features --features std
+	@echo "✅ Feature matrix OK — parallel/rayon correctly gated for wasm/minimal builds"
 
 # ============================================================================
 # COVERAGE (cargo llvm-cov test pattern — no nextest, no profraw explosion)

--- a/README.md
+++ b/README.md
@@ -117,14 +117,20 @@
 The CLI ships in the default feature set as of 0.2.9 ([#55](https://github.com/paiml/whisper.apr/issues/55)) — no `--features cli` flag required. The canonical binary name is `whisper-apr`; the older `whisper-apr-cli` alias was dropped.
 
 ```bash
-# Install (no feature flag needed)
-cargo install whisper-apr
+# Install the CLI. The default build transcribes local model files but does NOT
+# auto-download models. To enable auto-download (HuggingFace fetch +
+# safetensors→.apr conversion), add the `converter` feature — it pulls a heavier
+# dependency set (reqwest/tokio/zip), which is why it is opt-in.
+cargo install whisper-apr                       # transcribe with --model-path only
+cargo install whisper-apr --features converter  # + auto-download by --model name
 
 # Or from a local checkout
-cargo install --path .
+cargo install --path . --features converter
 
-# Transcribe audio (auto-downloads model)
-whisper-apr transcribe -f audio.wav
+# Transcribe audio. With --features converter this auto-downloads the model;
+# otherwise pass --model-path to a local .apr file.
+whisper-apr transcribe -f audio.wav --model tiny        # needs `converter`
+whisper-apr transcribe -f audio.wav --model-path model.apr  # works in default build
 
 # Use specific model
 whisper-apr transcribe -f audio.wav --model base

--- a/src/cli/model_loader.rs
+++ b/src/cli/model_loader.rs
@@ -807,8 +807,8 @@ pub fn load_or_download_model(
 
     #[cfg(not(feature = "converter"))]
     Err(ModelLoaderError::Download(format!(
-        "Model {:?} not cached and auto-download requires 'converter' feature. \
-         Use --model-path to specify a .apr file.",
+        "Model {:?} not cached; auto-download needs the 'converter' feature (off by default to keep deps small). \
+         Reinstall with `cargo install whisper-apr --features converter`, or pass --model-path <FILE.apr>.",
         size
     )))
 }

--- a/src/simd/matrix.rs
+++ b/src/simd/matrix.rs
@@ -75,25 +75,34 @@ pub fn matmul(a: &[f32], b: &[f32], rows: usize, inner: usize, cols: usize) -> V
     });
 
     if !used_profiler {
-        use rayon::prelude::*;
-        let num_threads = rayon::current_num_threads();
-        let chunk_rows = rows.div_ceil(num_threads);
-        let chunk_rows = chunk_rows.max(1);
-
-        if rows <= 512 {
-            c.par_chunks_mut(chunk_rows * cols)
-                .enumerate()
-                .for_each(|(i, c_chunk)| {
-                    let r_start = i * chunk_rows;
-                    let r_count = c_chunk.len() / cols;
-                    let a_chunk = &a[r_start * inner..(r_start + r_count) * inner];
-                    let _ =
-                        trueno::blis::gemm_blis(r_count, cols, inner, a_chunk, b, c_chunk, None);
-                });
-        } else if trueno::blis::parallel::gemm_blis_parallel(rows, cols, inner, a, b, &mut c)
-            .is_err()
+        #[cfg(feature = "parallel")]
         {
-            return vec![0.0; rows * cols];
+            use rayon::prelude::*;
+            let num_threads = rayon::current_num_threads();
+            let chunk_rows = rows.div_ceil(num_threads).max(1);
+
+            if rows <= 512 {
+                c.par_chunks_mut(chunk_rows * cols)
+                    .enumerate()
+                    .for_each(|(i, c_chunk)| {
+                        let r_start = i * chunk_rows;
+                        let r_count = c_chunk.len() / cols;
+                        let a_chunk = &a[r_start * inner..(r_start + r_count) * inner];
+                        let _ = trueno::blis::gemm_blis(
+                            r_count, cols, inner, a_chunk, b, c_chunk, None,
+                        );
+                    });
+            } else if trueno::blis::parallel::gemm_blis_parallel(rows, cols, inner, a, b, &mut c)
+                .is_err()
+            {
+                return vec![0.0; rows * cols];
+            }
+        }
+        // Serial fallback (no `parallel` feature, e.g. wasm32 where rayon is
+        // unavailable): single-threaded BLIS GEMM over the whole matrix.
+        #[cfg(not(feature = "parallel"))]
+        {
+            let _ = trueno::blis::gemm_blis(rows, cols, inner, a, b, &mut c, None);
         }
     }
     c
@@ -164,39 +173,55 @@ pub fn matmul_with_prepacked(
 
     let mut c = vec![0.0_f32; rows * cols];
 
-    if rows <= 512 {
-        use rayon::prelude::*;
-        let num_threads = rayon::current_num_threads();
-        let chunk_rows = rows.div_ceil(num_threads);
-        let chunk_rows = chunk_rows.max(1);
-
-        c.par_chunks_mut(chunk_rows * cols)
-            .enumerate()
-            .for_each(|(i, c_chunk)| {
-                let r_start = i * chunk_rows;
-                let r_count = c_chunk.len() / cols;
-                let a_chunk = &a[r_start * inner..(r_start + r_count) * inner];
-                let _ = trueno::blis::gemm_blis_with_prepacked_b(
-                    r_count,
-                    cols,
-                    inner,
-                    a_chunk,
-                    prepacked_b,
-                    c_chunk,
-                    None,
-                );
-            });
-    } else if trueno::blis::parallel::gemm_blis_parallel_with_prepacked_b(
-        rows,
-        cols,
-        inner,
-        a,
-        prepacked_b,
-        &mut c,
-    )
-    .is_err()
+    #[cfg(feature = "parallel")]
     {
-        return vec![0.0; rows * cols];
+        use rayon::prelude::*;
+        if rows <= 512 {
+            let num_threads = rayon::current_num_threads();
+            let chunk_rows = rows.div_ceil(num_threads).max(1);
+
+            c.par_chunks_mut(chunk_rows * cols)
+                .enumerate()
+                .for_each(|(i, c_chunk)| {
+                    let r_start = i * chunk_rows;
+                    let r_count = c_chunk.len() / cols;
+                    let a_chunk = &a[r_start * inner..(r_start + r_count) * inner];
+                    let _ = trueno::blis::gemm_blis_with_prepacked_b(
+                        r_count,
+                        cols,
+                        inner,
+                        a_chunk,
+                        prepacked_b,
+                        c_chunk,
+                        None,
+                    );
+                });
+        } else if trueno::blis::parallel::gemm_blis_parallel_with_prepacked_b(
+            rows,
+            cols,
+            inner,
+            a,
+            prepacked_b,
+            &mut c,
+        )
+        .is_err()
+        {
+            return vec![0.0; rows * cols];
+        }
+    }
+    // Serial fallback (no `parallel` feature, e.g. wasm32): single-threaded BLIS
+    // GEMM with the prepacked B panel over the whole matrix.
+    #[cfg(not(feature = "parallel"))]
+    {
+        let _ = trueno::blis::gemm_blis_with_prepacked_b(
+            rows,
+            cols,
+            inner,
+            a,
+            prepacked_b,
+            &mut c,
+            None,
+        );
     }
     c
 }

--- a/src/simd/optimized.rs
+++ b/src/simd/optimized.rs
@@ -113,9 +113,6 @@ pub fn tiled_matmul_into(
     rows: usize,
     cols: usize,
 ) {
-    #[cfg(feature = "parallel")]
-    use rayon::prelude::*;
-
     assert_eq!(weights.len(), rows * cols);
     assert_eq!(input.len(), seq_len * cols);
     assert_eq!(out.len(), seq_len * rows);
@@ -125,47 +122,48 @@ pub fn tiled_matmul_into(
     #[cfg(not(target_arch = "x86_64"))]
     let use_avx2 = false;
 
-    // Parallelize over chunks of the output features (rows).
-    // This allows each thread to keep a small slice of the weights in L1/L2 cache
-    // and reuse it across all sequence tokens, maximizing memory bandwidth.
+    // `out` is written via a raw pointer (carried as usize) so this closure is
+    // Send + Sync; parallel chunks touch disjoint output ranges, so no data race.
     let out_ptr = out.as_mut_ptr() as usize;
-
-    let num_threads = rayon::current_num_threads();
-    let chunk_size = rows.div_ceil(num_threads);
-    let chunk_size = chunk_size.max(1);
-
-    (0..rows)
-        .into_par_iter()
-        .step_by(chunk_size)
-        .for_each(|r_start| {
-            let r_end = (r_start + chunk_size).min(rows);
-            for s in 0..seq_len {
-                let in_row = &input[s * cols..(s + 1) * cols];
-                for i in r_start..r_end {
-                    let row_offset = i * cols;
-                    let a_slice = &weights[row_offset..row_offset + cols];
-
-                    let dot = if use_avx2 {
-                        #[cfg(target_arch = "x86_64")]
-                        // SAFETY: Target architecture ensures AVX2 is supported
-                        unsafe {
-                            crate::simd::vector::dot_fma_avx2_public(a_slice, in_row)
-                        }
-                        #[cfg(not(target_arch = "x86_64"))]
-                        crate::simd::vector::dot_scalar(a_slice, in_row)
-                    } else {
-                        crate::simd::vector::dot_scalar(a_slice, in_row)
-                    };
-
-                    // SAFETY: Pointer is valid and within bounds
+    let compute_range = |r_start: usize, r_end: usize| {
+        for s in 0..seq_len {
+            let in_row = &input[s * cols..(s + 1) * cols];
+            for i in r_start..r_end {
+                let a_slice = &weights[i * cols..i * cols + cols];
+                let dot = if use_avx2 {
+                    #[cfg(target_arch = "x86_64")]
+                    // SAFETY: Target architecture ensures AVX2 is supported
                     unsafe {
-                        // out is [seq_len, rows]
-                        let ptr = out_ptr as *mut f32;
-                        *ptr.add(s * rows + i) = dot;
+                        crate::simd::vector::dot_fma_avx2_public(a_slice, in_row)
                     }
+                    #[cfg(not(target_arch = "x86_64"))]
+                    crate::simd::vector::dot_scalar(a_slice, in_row)
+                } else {
+                    crate::simd::vector::dot_scalar(a_slice, in_row)
+                };
+                // SAFETY: pointer valid and within bounds; out is [seq_len, rows]
+                unsafe {
+                    *(out_ptr as *mut f32).add(s * rows + i) = dot;
                 }
             }
-        });
+        }
+    };
+
+    // Parallelize over row chunks when `parallel` is enabled (each thread keeps a
+    // weight slice hot in L1/L2 and reuses it across tokens); fall back to a serial
+    // pass on wasm32/minimal builds where rayon is unavailable.
+    #[cfg(feature = "parallel")]
+    {
+        use rayon::prelude::*;
+        let num_threads = rayon::current_num_threads();
+        let chunk_size = rows.div_ceil(num_threads).max(1);
+        (0..rows)
+            .into_par_iter()
+            .step_by(chunk_size)
+            .for_each(|r_start| compute_range(r_start, (r_start + chunk_size).min(rows)));
+    }
+    #[cfg(not(feature = "parallel"))]
+    compute_range(0, rows);
 }
 
 /// RMS normalization (faster than LayerNorm).


### PR DESCRIPTION
## Summary

Dogfooding the freshly-published **0.3.1** surfaced that the crate **does not compile for wasm32** or any `default-features = false, features = ["std"]` consumer — the flagship WASM-first target was broken. This cuts **0.3.2** to fix it, with a regression guard so it can't recur.

### Root cause (Genchi Genbutsu)
`simd::optimized::tiled_matmul_into` and `simd::matrix::{matmul, matmul_with_prepacked}` called `rayon` (`current_num_threads`, `into_par_iter`, `par_chunks_mut`) with **no `#[cfg(feature = "parallel")]` guard**, but `rayon` is gated behind the `parallel` feature (not implied by `std`/`wasm`). Building with default features (which include `parallel`) masked the break.

### Fix
- Each SIMD site now gates the parallel path and adds a single-threaded serial fallback (same pattern as the other SIMD functions). wasm/minimal now compiles with **0 errors** (a few benign dead-code/unused-import warnings remain in feature-gated + generated code — pre-existing, non-blocking).

### Jidoka — build quality in
- New `make check-features` compiles the crate for **wasm** and the **minimal `std`-only** config; wired into `make tier2` so this class of feature-gating regression is caught before merge.
- Fixed `make build-wasm` to use `--no-default-features` (it built the wasm-incompatible default set — which is why the regression went unnoticed).

### Bug 2 (auto-download needs `converter`) — docs, not a code change
Confirmed by-design (the `converter` feature carries the safetensors→.apr conversion + reqwest/tokio and is kept opt-in to preserve the 809→567 dep reduction). Made the CLI error message actionable and corrected the README's out-of-box auto-download claim instead of bloating the default feature set.

## Verification
- `cargo build --target wasm32-unknown-unknown --no-default-features --features wasm` → 0 errors
- `cargo build --no-default-features --features std` → 0 errors
- `cargo test --lib` → **2904 passed, 0 failed**
- `cargo clippy --lib --bins -- -D warnings` → clean
- `cargo fmt --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)